### PR TITLE
chore: update the async response

### DIFF
--- a/basic_kyc.go
+++ b/basic_kyc.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 )
 
-func (c *Client) BasicKYCAsyncVerification(ctx context.Context, input *KYCInput) (*KYCVerificationResult, error) {
-	var resp KYCVerificationResult
+func (c *Client) BasicKYCAsyncVerification(ctx context.Context, input *KYCInput) (*AsyncResponse, error) {
+	var resp AsyncResponse
 
 	err := c.makeRequest(ctx, http.MethodPost, "v2/verify_async", nil, input, resp)
 	if err != nil {

--- a/models.go
+++ b/models.go
@@ -56,3 +56,7 @@ type KYCVerificationResult struct {
 	Timestamp         time.Time     `json:"timestamp,omitempty"`
 	Source            string        `json:"Source,omitempty"`
 }
+
+type AsyncResponse struct {
+	Success bool `json:"success,omitempty"`
+}


### PR DESCRIPTION
Async endpoints return a different response from the synchronous endpoint. It basically returns a boolean value. The verification response from the async endpoint is sent to a callback url